### PR TITLE
events can now be deleted, user redirected to the event list

### DIFF
--- a/src/components/events/EventDetail.js
+++ b/src/components/events/EventDetail.js
@@ -6,7 +6,7 @@ import { useParams, useHistory } from "react-router-dom"
 
 export const EventDetail = () => {
 
-    const { getEventById } = useContext(EventContext)
+    const { getEventById, deleteEvent } = useContext(EventContext)
     const [event, setEvent] = useState({})
     
     const { getUserById } = useContext(UserContext)
@@ -19,6 +19,7 @@ export const EventDetail = () => {
     //get user Id from session storage
     const currentUserId = +sessionStorage.getItem("nutshell_user")
 
+    // Get details for specific event and it's creator
     useEffect(() => {
         getEventById(eventId)
             .then(response => {
@@ -31,6 +32,13 @@ export const EventDetail = () => {
             })
     }, [])
 
+    // Delete event button function
+    const handleDelete = () => {
+        deleteEvent(eventId)
+            .then(() => {
+                history.push("/events")
+            })
+    }
     
     return (
         <section className="event__item">
@@ -38,6 +46,7 @@ export const EventDetail = () => {
             <div className="event__date">{event.date}</div>
             <div className="event__info">Description: {event.info}</div>
             <div className="event__user">Host: {user.name}</div>
+            <button onClick={handleDelete}>Delete Event</button>
         </section>
     )
 }

--- a/src/components/events/EventDetail.js
+++ b/src/components/events/EventDetail.js
@@ -12,7 +12,7 @@ export const EventDetail = () => {
     const { getUserById } = useContext(UserContext)
     const [user, setUser] = useState({})
     
-    
+    console.log("expanded event object", event)
     
     const history = useHistory()
     const { eventId } = useParams()
@@ -26,10 +26,10 @@ export const EventDetail = () => {
                 setEvent(response)
             })
 
-        getUserById(currentUserId)
-            .then(response => {
-                setUser(response)
-            })
+        // getUserById(currentUserId)
+        //     .then(response => {
+        //         setUser(response)
+            // })
     }, [])
 
     // Delete event button function
@@ -45,7 +45,7 @@ export const EventDetail = () => {
             <h4 className="event__title">{event.title}</h4>
             <div className="event__date">{event.date}</div>
             <div className="event__info">Description: {event.info}</div>
-            <div className="event__user">Host: {user.name}</div>
+            <div className="event__user">Host: {event.user?.name}</div>
             <button onClick={handleDelete}>Delete Event</button>
         </section>
     )

--- a/src/components/events/EventDetail.js
+++ b/src/components/events/EventDetail.js
@@ -46,7 +46,7 @@ export const EventDetail = () => {
             <div className="event__date">{event.date}</div>
             <div className="event__info">Description: {event.info}</div>
             <div className="event__user">Host: {event.user?.name}</div>
-            <button onClick={handleDelete}>Delete Event</button>
+            {currentUserId === event.userId? <button onClick={handleDelete}>Delete Event</button> : ""}
         </section>
     )
 }

--- a/src/components/events/EventProvider.js
+++ b/src/components/events/EventProvider.js
@@ -25,7 +25,7 @@ export const EventProvider = (props) => {
     }
 
     const getEventById = (id) => {
-        return fetch(`http://localhost:8088/events/${id}`)
+        return fetch(`http://localhost:8088/events/${id}?_expand=user`)
             .then(res => res.json())
     }
 

--- a/src/components/events/EventProvider.js
+++ b/src/components/events/EventProvider.js
@@ -46,9 +46,16 @@ export const EventProvider = (props) => {
             .then(setEvents)
     }
 
+    const deleteEvent = eventId => {
+        return fetch(`http://localhost:8088/events/${eventId}`, {
+            method: "DELETE"
+        })
+        .then(getEvents)
+    }
+
     return (
         <EventContext.Provider value ={{
-            events, getEvents, addEvent, updateEvent, getEventById, getEventsByUserId
+            events, getEvents, addEvent, updateEvent, getEventById, getEventsByUserId, deleteEvent
         }}>
             {props.children}
         </EventContext.Provider>


### PR DESCRIPTION
# Description

Events can be deleted

Fixes # (issue) _Fixed bug where event details card showed the currentuser as the host instead of the _creator__

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions

Please describe the tests required to verify your changes. Provide instructions so PR Tester can check functionality. Please also list any relevant details for your tests
```
git fetch --all
git checkout dm-eventDelete
```
**Check to see that events are deleted. Events are only rendered based on current user anyway so right now all events will have delete button but in a future state the app will allow the current user to see friend's events and then the button should not be there for friend events**

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
